### PR TITLE
#156655678 Bug: can't set headers after they are sent

### DIFF
--- a/server/controllers/chats.js
+++ b/server/controllers/chats.js
@@ -9,14 +9,10 @@ let userAttributes = {
 const findChatById = (id, res) => {
   return Chat.findById(id, { include: userAttributes })
     .then(chat => {
-      if (!chat) {
-        return res.status(404)
-          .send({ message: 'Chat not found', status: 'fail' });
-      }
       return chat;
     })
     .catch(error => {
-      res.status(400).send(error);
+      throw(error);
     });
 };
 
@@ -61,10 +57,14 @@ module.exports = {
   findById(req, res) {
     return findChatById(req.params.id, res)
       .then(chat => {
+        if (!chat) {
+          return res.status(404)
+            .send({ message: 'Chat not found', status: 'fail' });
+        }
         return res.status(200).send({ data: chat, status: 'success' });
       })
       .catch(error => {
-        res.status(400).send(error);
+        return res.status(400).send(error);
       });
   },
 

--- a/server/controllers/incidents.js
+++ b/server/controllers/incidents.js
@@ -74,15 +74,10 @@ const findOrCreateUser = userType => {
 const findIncidentById = (id, res) => {
   return Incident.findById(id, { include: includes })
     .then(incident => {
-      if (!incident) {
-        return res.status(404).send({ message: 'Incident not found', status: 'fail' });
-      }
-      incident.assignees && mapAssignees(incident.assignees);
-      incident.dataValues.reporter = incident.dataValues.reporter[0];
       return incident;
     })
     .catch(error => {
-      return error;
+      throw(error);
     });
 };
 
@@ -176,10 +171,16 @@ module.exports = {
   findById(req, res) {
     return findIncidentById(req.params.id, res)
       .then(incident => {
-        res.status(200).send({ data: incident, status: 'success' });
+        if (!incident) {
+          return res.status(404)
+            .send({ message: 'Incident not found', status: 'fail' });
+        }
+        incident.assignees && mapAssignees(incident.assignees);
+        incident.dataValues.reporter = incident.dataValues.reporter[0];
+        return res.status(200).send({ data: incident, status: 'success' });
       })
       .catch(error => {
-        res.status(400).send(error);
+        return res.status(400).send(error);
       });
   },
 

--- a/server/controllers/notes.js
+++ b/server/controllers/notes.js
@@ -9,14 +9,10 @@ let userAttributes = {
 const findNoteById = (id, res) => {
   return Note.findById(id, { include: userAttributes })
     .then(note => {
-      if (!note) {
-        return res.status(404)
-          .send({ message: 'Note not found', status: 'fail' });
-      }
       return note;
     })
     .catch(error => {
-      res.status(400).send(error);
+      throw(error);
     });
 };
 
@@ -61,10 +57,14 @@ module.exports = {
   findById(req, res) {
     return findNoteById(req.params.id, res)
       .then(note => {
+        if (!note) {
+          return res.status(404)
+            .send({ message: 'Note not found', status: 'fail' });
+        }
         return res.status(200).send({ data: note, status: 'success' });
       })
       .catch(error => {
-        res.status(400).send(error);
+        return res.status(400).send(error);
       });
   },
 


### PR DESCRIPTION
#### What does this PR do?
Fixes `converting circular structure to json`
#### Description of Task to be completed?
When someone tries to find by ID an incident/note/chat that doesn't exist, it gives a 404 as it should on postman and a message; on the terminal: the error is a 400: `can't set headers after they are sent`. On logging the error, we get `converting circular structure to json`
#### Where should the reviewer start?
Files changed
#### How should this be manually tested?
Test findById endpoints
#### What are the relevant pivotal tracker stories?
[#156655678](https://www.pivotaltracker.com/story/show/156655678)
#### Screenshots (if appropriate)
<img width="637" alt="screen shot 2018-04-10 at 5 17 26 pm" src="https://user-images.githubusercontent.com/27012508/38562666-c89e0b38-3ce3-11e8-8ca9-9a052a363087.png">
<img width="1054" alt="screen shot 2018-04-10 at 5 17 46 pm" src="https://user-images.githubusercontent.com/27012508/38562667-c8dd2728-3ce3-11e8-8e55-414cfec5d758.png">
Fixed to:
<img width="634" alt="screen shot 2018-04-10 at 5 19 05 pm" src="https://user-images.githubusercontent.com/27012508/38562873-409571a8-3ce4-11e8-8fd2-73764d184f06.png">
<img width="1068" alt="screen shot 2018-04-10 at 5 19 11 pm" src="https://user-images.githubusercontent.com/27012508/38562874-40ef2c20-3ce4-11e8-9c5e-3f2693b19960.png">
