### PR TITLE
Bg enable assignees to view incidents 160291760

### DIFF
--- a/src/server/middlewares/authentication.js
+++ b/src/server/middlewares/authentication.js
@@ -34,8 +34,17 @@ const isAdmin = (req, res, next) => {
   }
   res.status(403).send({ message: 'You are not an Authorised user' });
 };
+
+const isAssignee = (req, res, next) => {
+  const Assignee = 2;
+  if (res.locals.roleId === Assignee) {
+    return next();
+  }
+  res.status(403).send({ message: 'You are not an Authorised user' });
+};
+
 const token = (id, roleId) => {
   return jwt.sign({ id, roleId }, secretKey, { expiresIn: '24h' });
 };
 
-module.exports = { isAdmin, Auth, token };
+module.exports = { isAdmin, isAssignee, Auth, token };

--- a/src/server/middlewares/authentication.js
+++ b/src/server/middlewares/authentication.js
@@ -35,9 +35,16 @@ const isAdmin = (req, res, next) => {
   res.status(403).send({ message: 'You are not an Authorised user' });
 };
 
-const isAssignee = (req, res, next) => {
-  const Assignee = 2;
-  if (res.locals.roleId === Assignee) {
+/**
+* Checks if user viewing incidents is an assignee or admin
+* @function canViewIncidents
+* @param Request Object
+* @param Response Object
+* @param function next()
+**/
+const canViewIncidents = (req, res, next) => {
+  const roleId = res.locals.roleId;
+  if (roleId === 2 || roleId === 3) {
     return next();
   }
   res.status(403).send({ message: 'You are not an Authorised user' });
@@ -47,4 +54,4 @@ const token = (id, roleId) => {
   return jwt.sign({ id, roleId }, secretKey, { expiresIn: '24h' });
 };
 
-module.exports = { isAdmin, isAssignee, Auth, token };
+module.exports = { isAdmin, canViewIncidents, Auth, token };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -7,7 +7,7 @@ const chatsService = controllers.chats;
 const usersService = controllers.users;
 const rolesService = controllers.roles;
 
-const { Auth, isAdmin, isAssignee } = require('../middlewares/authentication'); // authorise routes
+const { Auth, isAdmin, canViewIncidents } = require('../middlewares/authentication'); // authorise routes
 
 module.exports = app => {
   app.get('/api', (req, res) =>
@@ -17,9 +17,9 @@ module.exports = app => {
   );
   // incidents endpoints
   app.post('/api/incidents', incidentsService.create);
-  app.get('/api/incidents', [Auth, isAdmin, isAssignee], incidentsService.list);
+  app.get('/api/incidents', [Auth, canViewIncidents], incidentsService.list);
   app.get('/api/incidents/:id', [Auth, isAdmin], incidentsService.findById);
-  app.put('/api/incidents/:id', Auth, incidentsService.update);
+  app.put('/api/incidents/:id', [Auth, canViewIncidents], incidentsService.update);
   app.get('/api/search/incidents', [Auth, isAdmin], incidentsService.search);
   app.delete('/api/incidents/:id', [Auth, isAdmin], incidentsService.delete);
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -7,7 +7,7 @@ const chatsService = controllers.chats;
 const usersService = controllers.users;
 const rolesService = controllers.roles;
 
-const { Auth, isAdmin } = require('../middlewares/authentication'); // authorise routes
+const { Auth, isAdmin, isAssignee } = require('../middlewares/authentication'); // authorise routes
 
 module.exports = app => {
   app.get('/api', (req, res) =>
@@ -17,7 +17,7 @@ module.exports = app => {
   );
   // incidents endpoints
   app.post('/api/incidents', incidentsService.create);
-  app.get('/api/incidents', [Auth, isAdmin], incidentsService.list);
+  app.get('/api/incidents', [Auth, isAdmin, isAssignee], incidentsService.list);
   app.get('/api/incidents/:id', [Auth, isAdmin], incidentsService.findById);
   app.put('/api/incidents/:id', Auth, incidentsService.update);
   app.get('/api/search/incidents', [Auth, isAdmin], incidentsService.search);


### PR DESCRIPTION
#### What does this PR do?
Create new `isAssignee` auth group
#### Description of Task to be completed?
When an assignee who had been invited to WIRE tried to view the incidents that were assigned to them they couldn't cause they were not authorized. This task was to remedy that situation.
#### What are the relevant pivotal tracker stories?
[#160291760](https://www.pivotaltracker.com/story/show/160291760)
#### Screenshots (if appropriate)
N/A
