### PR TITLE
Feature send emails to Andela emails only

### DIFF
--- a/src/server/helpers/checkEmail.js
+++ b/src/server/helpers/checkEmail.js
@@ -1,0 +1,16 @@
+/**
+* Checks if the email provided is an Andela email address 
+* @function checkEmail
+* @param Email
+* @return String
+**/
+const checkEmail = emailAddress => {
+  const idx = emailAddress.lastIndexOf('@');
+  if (idx > -1 && emailAddress.slice(idx + 1) === 'andela.com') {
+    
+    return true;
+  }
+  return false;
+};
+
+module.exports = checkEmail;

--- a/src/server/helpers/checkEmail.js
+++ b/src/server/helpers/checkEmail.js
@@ -2,12 +2,11 @@
 * Checks if the email provided is an Andela email address 
 * @function checkEmail
 * @param Email
-* @return String
+* @return Boolean
 **/
 const checkEmail = emailAddress => {
-  const idx = emailAddress.lastIndexOf('@');
-  if (idx > -1 && emailAddress.slice(idx + 1) === 'andela.com') {
-    
+
+  if (emailAddress.endsWith('@andela.com')) {
     return true;
   }
   return false;

--- a/src/server/helpers/checkEmail.js
+++ b/src/server/helpers/checkEmail.js
@@ -4,12 +4,5 @@
 * @param Email
 * @return Boolean
 **/
-const checkEmail = emailAddress => {
-
-  if (emailAddress.endsWith('@andela.com')) {
-    return true;
-  }
-  return false;
-};
-
+const checkEmail = emailAddress => emailAddress.endsWith('@andela.com');
 module.exports = checkEmail;

--- a/src/server/helpers/generateAssigneeOrCcdEmailBody.js
+++ b/src/server/helpers/generateAssigneeOrCcdEmailBody.js
@@ -19,7 +19,7 @@ module.exports = async userDetails => {
         subject: 'An incident has been assigned.' ,
         message: `Hi <strong>${name.first} ${name.last} </strong>,<br/> 
       A user has been assinged this </strong>. 
-      <a href="${config.WIRE_BASE_URL}/incidents/${userDetails.incidentId}">Incident</a>.`,
+      <a href="${config.WIRE_BASE_URL}/timeline/${userDetails.incidentId}">Incident</a>.`,
         to: userDetails.email,
       };
       return body;
@@ -29,7 +29,7 @@ module.exports = async userDetails => {
       subject: 'You have been assigned an incident',
       message: `Hi <strong>${name.first} ${name.last} </strong>,<br/> 
       You've been assigned an incident on <strong>WIRE(Workspace Incident Reporting)</strong>. 
-      Click <a href="${config.WIRE_BASE_URL}/incidents/${userDetails.incidentId}">here</a> to view it.`,
+      Click <a href="${config.WIRE_BASE_URL}/timeline/${userDetails.incidentId}">here</a> to view it.`,
       to: userDetails.email,
     };
     return body;

--- a/src/server/helpers/getUsernameFromEmail.js
+++ b/src/server/helpers/getUsernameFromEmail.js
@@ -6,8 +6,23 @@
 
 module.exports = email => {
   let name = {};
-  const [firstName, lastName] = email.split('@')[0].split('.');
-  const first = firstName[0].toUpperCase() + firstName.substr(1, firstName.length);
-  const last = lastName[0].toUpperCase() + lastName.substr(1, lastName.length);
-  return name = {first, last};
+  let first, last = '';
+  const email_username = email.split('@')[0].split('.');
+  if (email_username.length > 1) {
+    // email has '.'
+    first =
+      email_username[0].charAt(0).toUpperCase() + email_username[0].slice(1);
+
+    last =
+      email_username[1].charAt(0).toUpperCase() + email_username[1].slice(1);
+
+    name = { first, last };
+  } else {
+    // email doesn't have '.'
+    first =
+      email_username[0].charAt(0).toUpperCase() + email_username[0].slice(1);
+
+    name = { first, last };
+  }
+  return name;
 };

--- a/src/test/users.js
+++ b/src/test/users.js
@@ -177,7 +177,7 @@ describe('/POST user', () => {
     request(app)
       .post('/api/users/invite')
       .send({
-        'email': 'oliver.munala@me.com',
+        'email': 'oliver.munala@andela.com',
         'roleId': 3,
         'locationId': 'cjee24cz40000guxs6bdner6l'
       })


### PR DESCRIPTION
#### What does this PR do?
Limits the sending of invite emails to none Andela emails and also changes the API validation for sending emails.
#### What are the relevant pivotal tracker stories?
[#160478479](https://www.pivotaltracker.com/story/show/160478479)
[#160478420](https://www.pivotaltracker.com/story/show/160478420)
#### Screenshots (if appropriate)
N/A
