### PR TITLE
Prevent sending invites to already available assignee/admin

### DIFF
--- a/src/server/controllers/users.js
+++ b/src/server/controllers/users.js
@@ -155,7 +155,7 @@ module.exports = {
           const userExists = await User.findOne({where: {email: req.body.email}});
           if(!created) {
             if(userExists.roleId === req.body.roleId) {
-              const roleName = await matchRoleIdToRoleName(req.body.roleId);
+              const roleName = await matchRoleIdToRoleName(userExists.roleId);
               return res.status(400).send({ message: `The user with that email address already exists as an ${roleName} . Try updating their role` });
             } else {
               await updateUserAndSendMail(userObject, res);

--- a/src/server/controllers/users.js
+++ b/src/server/controllers/users.js
@@ -138,46 +138,35 @@ module.exports = {
   async inviteUser(req, res) {
     const validEmail = checkEmail(req.body.email);
     if (validEmail) {
-      const userExists = await User.findOne( {where: {email: req.body.email}} );
-      if (userExists) {
-        return res.status(400).send({ message: 'The user with that email address already exists' });
-      } else {
-        const name = getUsernameFromEmail(req.body.email);
-        res.locals.username = name.first + ' ' + name.last;
-        const userObject = {
-          email: req.body.email,
-          username: res.locals.username,
-          roleId: req.body.roleId,
-          locationId: req.body.locationId
-        };
-        return User.findOrCreate({where: { email: userObject.email},
-          defaults: userObject})
-          .spread( async (createdUser, created) => {
-            if(!created) {
-              await User.update(req.body,{
-                where: {
-                  email: userObject.email
-                },
-                returning: true
-              });
-              return res.status(200).send({ message: 'the user role has been updated' });
+      const name = getUsernameFromEmail(req.body.email);
+      res.locals.username = name.first + ' ' + name.last;
+      const userObject = {
+        email: req.body.email,
+        username: res.locals.username,
+        roleId: req.body.roleId,
+        locationId: req.body.locationId
+      };
+      return User.findOrCreate({where: { email: userObject.email},
+        defaults: userObject})
+        .spread( async (createdUser, created) => {
+          if(!created) {
+            return res.status(400).send({ message: 'The user with that email address already exists' });
+          }
+          const emailBody = await generateEmailBody(req.body.email, req.body.roleId);
+          const callback = (error) => {
+            if (error) {
+              return error;
             }
-            const emailBody = await generateEmailBody(req.body.email, req.body.roleId);
-            const callback = (error) => {
-              if (error) {
-                return error;
-              }
-              return {message: 'The email was sent successfully'};
-            };
-            emailHelper.sendMail(emailBody, callback);
-            const user = await User.findById(createdUser.id, { include: includes});
-            return res.status(200).send({ data: user, status: 'success' });
-          })
-          .catch(error => {
-            errorLogs.catchErrors(error);
-            res.status(400).send(error);
-          });
-      }
+            return {message: 'The email was sent successfully'};
+          };
+          emailHelper.sendMail(emailBody, callback);
+          const user = await User.findById(createdUser.id, { include: includes});
+          return res.status(200).send({ data: user, status: 'success' });
+        })
+        .catch(error => {
+          errorLogs.catchErrors(error);
+          res.status(400).send(error);
+        });
     }
     res.status(400).send('You can only invite Andela users through their Andela emails');
   },

--- a/src/server/controllers/users.js
+++ b/src/server/controllers/users.js
@@ -10,6 +10,8 @@ const { token } = require('../middlewares/authentication');
 const getUsernameFromEmail = require('../helpers/getUsernameFromEmail');
 const Sequelize = require('sequelize');
 const checkEmail = require('../helpers/checkEmail');
+const updateUserAndSendMail = require('../helpers/updateUserAndSendMail');
+
 require('dotenv').config();
 
 const jwt = require('jsonwebtoken');
@@ -154,13 +156,7 @@ module.exports = {
             if(userExists.roleId === req.body.roleId) {
               return res.status(400).send({ message: 'The user with that email address already exists as an {assignee/admin}. Try updating their role' });
             } else {
-              await User.update(req.body,{
-                where: {
-                  email: userObject.email
-                },
-                returning: true
-              });
-              return res.status(200).send({ message: 'the user role has been updated' });
+              await updateUserAndSendMail(userObject, res);
             }
           }
           const emailBody = await generateEmailBody(req.body.email, req.body.roleId);

--- a/src/server/controllers/users.js
+++ b/src/server/controllers/users.js
@@ -11,6 +11,7 @@ const getUsernameFromEmail = require('../helpers/getUsernameFromEmail');
 const Sequelize = require('sequelize');
 const checkEmail = require('../helpers/checkEmail');
 const updateUserAndSendMail = require('../helpers/updateUserAndSendMail');
+const matchRoleIdToRoleName = require('../helpers/matchRoleIdToRoleName');
 
 require('dotenv').config();
 
@@ -154,7 +155,8 @@ module.exports = {
           const userExists = await User.findOne({where: {email: req.body.email}});
           if(!created) {
             if(userExists.roleId === req.body.roleId) {
-              return res.status(400).send({ message: 'The user with that email address already exists as an {assignee/admin}. Try updating their role' });
+              const roleName = await matchRoleIdToRoleName(req.body.roleId);
+              return res.status(400).send({ message: `The user with that email address already exists as an ${roleName} . Try updating their role` });
             } else {
               await updateUserAndSendMail(userObject, res);
             }

--- a/src/server/helpers/updateUserAndSendMail.js
+++ b/src/server/helpers/updateUserAndSendMail.js
@@ -1,0 +1,26 @@
+const User = require('../models').Users;
+const generateEmailBody = require('../helpers/generateEmailBody');
+const emailHelper = require('../helpers/emailHelper');
+/**
+ * @function updateUserRoleAndSendMail
+ * @param Object body
+ * @return Status Code & Object
+ */
+
+module.exports = async (body, res) => {
+  await User.update(body,{
+    where: {
+      email: body.email
+    },
+    returning: true
+  });
+  const emailBody = await generateEmailBody(body.email, body.roleId);
+  const callback = (error) => {
+    if (error) {
+      return error;
+    }
+    return {message: 'The email was sent successfully'};
+  };
+  emailHelper.sendMail(emailBody, callback);
+  return res.status(200).send({ message: 'the user role has been updated' });
+};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -18,7 +18,7 @@ module.exports = app => {
   // incidents endpoints
   app.post('/api/incidents', incidentsService.create);
   app.get('/api/incidents', [Auth, canViewIncidents], incidentsService.list);
-  app.get('/api/incidents/:id', [Auth, isAdmin], incidentsService.findById);
+  app.get('/api/incidents/:id', [Auth, canViewIncidents], incidentsService.findById);
   app.put('/api/incidents/:id', [Auth, canViewIncidents], incidentsService.update);
   app.get('/api/search/incidents', [Auth, isAdmin], incidentsService.search);
   app.delete('/api/incidents/:id', [Auth, isAdmin], incidentsService.delete);

--- a/src/test/users.js
+++ b/src/test/users.js
@@ -164,7 +164,7 @@ describe('/POST user', () => {
       .expect(400)
       .end((err, res) => {
         if (err) throw err;
-        assert.equal(res.body.message, 'The user with that email address already exists as an {assignee/admin}. Try updating their role');
+        assert.equal(res.body.message, 'The user with that email address already exists as an Admin . Try updating their role');
         done();
       });
   });

--- a/src/test/users.js
+++ b/src/test/users.js
@@ -164,7 +164,7 @@ describe('/POST user', () => {
       .expect(400)
       .end((err, res) => {
         if (err) throw err;
-        assert.equal(res.body.message, 'The user with that email address already exists');
+        assert.equal(res.body.message, 'The user with that email address already exists as an {assignee/admin}. Try updating their role');
         done();
       });
   });

--- a/src/test/users.js
+++ b/src/test/users.js
@@ -153,18 +153,18 @@ describe('/POST user', () => {
       });
   });
 
-  it('InviteUser: Should update the user role if the user exists', (done) => {
+  it('InviteUser: Should not reinvite an existing user', (done) => {
     request(app)
       .post('/api/users/invite')
       .send({
         'email': 'eugene.omar@andela.com',
-        'roleId': 1,
-        'locationId': 'cjee24cz40000guxs6bdner6l'
+        'roleId': 3,
+        'locationId': 'cjkbgs8cz0000cmyxytfbkksu'
       })
-      .expect(200)
+      .expect(400)
       .end((err, res) => {
         if (err) throw err;
-        assert.equal(res.body.message, 'the user role has been updated');
+        assert.equal(res.body.message, 'The user with that email address already exists');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
- Add a check for whether a user already exists and stops them from being re-invited. 
#### How should this be manually tested?
- Clone this branch
- On Postman try to invite an existing `assignee` or `admin` 
- You should get a message informing you that you cannot invite an existing user
#### What are the relevant pivotal tracker stories?
[#160482024](https://www.pivotaltracker.com/story/show/160482024)
#### Screenshots (if appropriate)
N/A
