### PR TITLE
#166395417 Incident-slack channel relation API endpoint

### DIFF
--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -5,6 +5,7 @@ const categories = require('./categories');
 const users = require('./users');
 const roles = require('./roles');
 const slackEvents = require('./chats/slackEvents');
+const slackChannels = require('./slackChannels');
 const { catchErrors } = require('./errorLogs');
 
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   users,
   roles,
   slackEvents,
+  slackChannels,
   catchErrors,
 };

--- a/src/server/controllers/slackChannels.js
+++ b/src/server/controllers/slackChannels.js
@@ -1,0 +1,20 @@
+const SlackChannel = require('../models').SlackChannels
+
+module.exports = {
+  create: async (req, res) => {
+    let { incidentId, channelId, channelName, channelMembers } = req.body
+    const slackChannel = SlackChannel.create({
+      incidentId,
+      channelId,
+      channelName,
+      channelMembers
+    })
+      .then(response => {
+        res.status(201).send({ status: "success", data: response })
+      })
+      .catch(error => {
+        res.status(400).send({ status: "failure", error })
+      })
+
+  },
+}

--- a/src/server/middlewares/schemas/index.js
+++ b/src/server/middlewares/schemas/index.js
@@ -51,7 +51,7 @@ const incidentSchema = {
   statusId: Joi.number(),
   subject: Joi.string().required(),
   description: Joi.string().required(),
-  dateOccurred: Joi.date().required(),
+  dateOccurred: Joi.required(),
   levelId: Joi.string().required(),
   location: locationSchema,
   incidentReporter: incidentReporterSchema,

--- a/src/server/migrations/20190601184111-create-slack-channels.js
+++ b/src/server/migrations/20190601184111-create-slack-channels.js
@@ -1,0 +1,36 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('SlackChannels', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      incidentId: {
+        type: Sequelize.STRING
+      },
+      channelId: {
+        type: Sequelize.STRING
+      },
+      channelName: {
+        type: Sequelize.STRING
+      },
+      channelMembers: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('SlackChannels');
+  }
+};

--- a/src/server/models/slackchannels.js
+++ b/src/server/models/slackchannels.js
@@ -1,0 +1,22 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const SlackChannels = sequelize.define('SlackChannels', {
+    incidentId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    channelId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    channelName: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    channelMembers: DataTypes.STRING
+  }, {});
+  SlackChannels.associate = function(models) {
+    // associations can be defined here
+  };
+  return SlackChannels;
+};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -8,6 +8,7 @@ const categoriesService = controllers.categories;
 const usersService = controllers.users;
 const rolesService = controllers.roles;
 const slackEventsService = controllers.slackEvents;
+const slackChannelsService = controllers.slackChannels;
 const { catchErrors } = controllers;
 
 // authorise routes
@@ -37,6 +38,7 @@ module.exports = app => {
   //no auth needed
   app.post('/api/incidents', validateIncidentPayload, incidentsService.create);
   app.post('/api/users/login', usersService.login);
+  app.post('/api/slack/channel', slackChannelsService.create);
 
   // slack chats endpoints
   app.post( '/api/slack/chats', slackEventsService.createSlackEvent);

--- a/src/tests/slackChannel.spec.js
+++ b/src/tests/slackChannel.spec.js
@@ -1,0 +1,30 @@
+const { sendRequest } = require('./helpers/request');
+
+const testPayload = {
+	incidentId: "1",
+	channelId: "1",
+	channelName: "Channel name",
+	channelMembers: "6678"
+}
+
+const testPayloadBad = {
+	channelId: "1",
+	channelName: "Channel name",
+	channelMembers: "6678"
+}
+
+describe('Slack channel api test', () => {
+  it('should save incident slack channel relationship', done => {
+    sendRequest('post', '/api/slack/channel', testPayload, (err, res) => {
+      expect(res.body.status).toEqual('success');
+      done();
+    });
+  });
+
+  it('should return an error when data is not provided', done => {
+    sendRequest('post', '/api/slack/channel', testPayloadBad, (err, res) => {
+      expect(res.body.status).toEqual('failure');
+      done();
+    });
+  });
+})


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API endpoint to add the slack channel <> incident relation after an incident has been reported.

#### Description of Task to be completed?
- Add slack channel <> incident relation table.
- Add API endpoint to populate the relation table

#### How should this be manually tested?
- Set up the wirebot locally using the readme from the repo.
- Run all new migrations with command `yarn migrate`
- Report an incident.
- The slack channel <> incident relationship should have been saved.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#166395417](https://www.pivotaltracker.com/story/show/166395417)

#### Screenshots (if appropriate)
N/A
