### PR TITLE
#167455129 fix incident assignment

### DIFF
--- a/src/server/helpers/incidentHelper.js
+++ b/src/server/helpers/incidentHelper.js
@@ -193,7 +193,9 @@ const updateAssignedOrCcdUser = async (
     },
   });
 
-  await handleCCUpdateNotification(req, ccdUser, incident.id, '');
+  if (ccdUser && ccdUser.length > 0) {
+    await handleCCUpdateNotification(req, ccdUser, incident.id, '');
+  }
 
   return selectedUser.action({ ...selectedUser.arguments, incident, res });
 };
@@ -210,7 +212,6 @@ const updateIncident = async (incident, req, res) => {
     categoryId: req.body.categoryId || incident.categoryId,
     levelId: req.body.levelId || incident.levelId,
   });
-
   return res.status(200).send({ data: incident, status: 'success' });
 };
 

--- a/src/tests/incidents.spec.js
+++ b/src/tests/incidents.spec.js
@@ -80,14 +80,61 @@ describe('Incident Tests', () => {
       });
     });
   });
-
-  it('should update an incident provided an existing incident ID', done => {
+  it('should update an incident when someone gets assigned to the incident', done => {
     sendRequest('post', incidentsEndpoint, testIncident, (err, res) => {
-      const updateIncidentUrl = '/api/incidents/' + res.body.data.id;
+      const { id } = res.body.data;
+      const updateIncidentUrl = '/api/incidents/' + id;
       sendRequest(
         'put',
         updateIncidentUrl,
-        { ...testIncident, statusId: 3 },
+        {
+          ...testIncident,
+          assignee: {
+            userId: 'cjl6egyei00005dnytqp4a06l',
+            incidentId: id,
+          },
+        },
+        (error, response) => {
+          expect(response.body.status).toEqual('success');
+          done();
+        }
+      );
+    });
+  });
+  it('should update an incident when someone gets ccd to the incident', done => {
+    sendRequest('post', incidentsEndpoint, testIncident, (err, res) => {
+      const { id } = res.body.data;
+      const updateIncidentUrl = '/api/incidents/' + id;
+      sendRequest(
+        'put',
+        updateIncidentUrl,
+        {
+          ...testIncident,
+          ccd: [
+            {
+              userId: 'cjl6fecrb11115vf09xly2f65',
+              incidentId: id,
+            },
+          ],
+        },
+        (error, response) => {
+          expect(response.body.status).toEqual('success');
+          done();
+        }
+      );
+    });
+  });
+  it('should update an incident when the status is updated', done => {
+    sendRequest('post', incidentsEndpoint, testIncident, (err, res) => {
+      const { id } = res.body.data;
+      const updateIncidentUrl = '/api/incidents/' + id;
+      sendRequest(
+        'put',
+        updateIncidentUrl,
+        {
+          ...testIncident,
+          statusId: 3,
+        },
         (error, response) => {
           expect(response.body.data.statusId).toEqual(3);
           done();
@@ -96,10 +143,9 @@ describe('Incident Tests', () => {
     });
   });
 
-  it('should update an incident when someone gets assigned to it', done => {
+  it('should update an incident when someone gets ccd to it', done => {
     makeServerCall(assigneeRequestBody, done, 'put');
   });
-
   it('should update an incident when someone gets ccd to it', done => {
     makeServerCall(ccdRequestBody, done, 'put');
   });


### PR DESCRIPTION
#### What does this PR do?

fix to when you assign a user to an incident on the text box it is not saved, the assignment does not persist.
#### How should this be manually tested?

1. Navigate to the incident timeline page.
2. Assign a user to the incident.
3. Make sure both assigned and CC'ed users are all in place.

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[167455129](https://www.pivotaltracker.com/n/projects/2117172/stories/167455129)
#### Screenshots (if appropriate)
N/A
