### PR TITLE
 #167781111 Merge slackevents and wire web chats tables

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start:dev": "nodemon ./bin/www",
     "debug": "node --inspect ./bin/www",
-    "seed": "sequelize db:seed:undo:all && sequelize db:seed --seed levels && sequelize db:seed --seed categories && sequelize db:seed --seed status && sequelize db:seed --seed locations && sequelize db:seed --seed roles && sequelize db:seed --seed incidents && sequelize db:seed --seed users && sequelize db:seed --seed reporters && sequelize db:seed --seed witnesses && sequelize db:seed --seed notificationGroups && sequelize db:seed --seed notificationTypes && sequelize db:seed --seed notifications && sequelize db:seed --seed slackUsers && sequelize db:seed --seed slackEvents",
+    "seed": "sequelize db:seed:undo:all && sequelize db:seed --seed levels && sequelize db:seed --seed categories && sequelize db:seed --seed status && sequelize db:seed --seed locations && sequelize db:seed --seed roles && sequelize db:seed --seed incidents && sequelize db:seed --seed users && sequelize db:seed --seed reporters && sequelize db:seed --seed witnesses && sequelize db:seed --seed notificationGroups && sequelize db:seed --seed notificationTypes && sequelize db:seed --seed notifications && sequelize db:seed --seed slackUsers && sequelize db:seed --seed slackEvents && sequelize db:seed --seed slackChannels",
     "migrate": "sequelize db:migrate:undo:all && sequelize db:migrate",
     "lint": "./node_modules/.bin/eslint --fix ./server ./test",
     "migrate-seed": "npm run migrate && npm run seed",
@@ -26,7 +26,7 @@
     "axios": "0.19.0",
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
-    "cuid": "^2.1.0",
+    "cuid": "^2.1.6",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "joi": "14.3.0",

--- a/src/server/controllers/chats/slackEvents.js
+++ b/src/server/controllers/chats/slackEvents.js
@@ -1,5 +1,7 @@
-const slackEvent = require('../../models/index').slackEvents;
-const {slackUserRequest} = require('../../middlewares/index');
+/* eslint-disable indent */
+const slackEvent = require('../../models/index').SlackWireEvents;
+const { slackUserRequest } = require('../../middlewares/index');
+const slackUser = require('../../models/index').slackUsers;
 
 const createSlackEvents = payload => ({
   id: payload.event_id,
@@ -23,24 +25,25 @@ module.exports = {
   createSlackEvent: async (req, res) => {
     if (req.body.challenge) {
       const data = urlVerification(req);
-      return res.status(201).send({data, status: 'success'});
+      return res.status(201).send({ data, status: 'success' });
     }
     // Get event payload
     let payload = req.body;
-
     await slackUserRequest.getSlackUsers(payload.event.user);
-
-    slackEvent.create(createSlackEvents(payload))
+    slackEvent
+      .create(createSlackEvents(payload))
       .then(() => {
-        slackUserRequest.getSlackChannel(payload.event.channel, payload.event.user);
-
+        slackUserRequest.getSlackChannel(
+          payload.event.channel,
+          payload.event.user
+        );
         // slack response should be returned within 3 seconds
-        res.status(201).send({status: 'success'});
+        res.status(201).send({ status: 'success' });
       })
       .catch(err => {
         res.status(400).send({
           status: 'failure',
-          message: err.errors ? err.errors[0].message : err.message
+          message: err.errors ? err.errors[0].message : err.message,
         });
       });
   },

--- a/src/server/controllers/chats/webChats.js
+++ b/src/server/controllers/chats/webChats.js
@@ -1,0 +1,60 @@
+const models = require('../../models/index');
+const { postChat } = require('../../middlewares/index');
+
+require('dotenv').config();
+
+const message = {
+  message: 'there was an error posting your message to slack, try again',
+  status: 'failure',
+};
+
+module.exports = {
+  // eslint-disable-next-line max-lines-per-function
+  createAppChat: async (req, res) => {
+    if (req.body.text.length === 0) {
+      return res
+        .status(400)
+        .send({ message: 'Text is required', status: 'failure' });
+    }
+    let channelID;
+    const { incidentId } = req.body;
+    try {
+      const SlackChannel = await models.SlackChannels.findAll({
+        attributes: ['channelId'],
+        where: { incidentId: incidentId },
+      });
+      const { channelId } = SlackChannel[0];
+      channelID = channelId;
+    } catch (err) {
+      return res
+        .status(400)
+        .send({ message: 'incident not found', status: 'failure' });
+    }
+    try {
+      const chat = await models.SlackWireEvents.create({
+        text: req.body.text,
+        type: 'web_message',
+        userId: res.locals.currentUser.id,
+        channelId: channelID,
+      });
+      // post chat to specific slack channel
+      postChat
+        .postChat(chat.text, channelID)
+        .then(response => {
+          if (response.ok) {
+            return res.status(201).send({ chat, status: 'success' });
+          }
+          return res.status(400).send(message);
+        })
+        .catch(() => {
+          return res.status(400).send(message);
+        });
+    } catch (err) {
+      res.status(500).send({
+        message:
+          'sorry an error occured. We could not complete your action, try again',
+        status: 'failure',
+      });
+    }
+  },
+};

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -7,6 +7,7 @@ const roles = require('./roles');
 const slackEvents = require('./chats/slackEvents');
 const slackChannels = require('./slackChannels');
 const { catchErrors } = require('./errorLogs');
+const appChats = require('./chats/webChats');
 
 module.exports = {
   incidents,
@@ -18,4 +19,5 @@ module.exports = {
   slackEvents,
   slackChannels,
   catchErrors,
+  appChats,
 };

--- a/src/server/middlewares/authentication.js
+++ b/src/server/middlewares/authentication.js
@@ -20,7 +20,6 @@ const Auth = (req, res, next) => {
         message: 'Invalid token provided',
       });
     }
-
     res.locals.currentUser = decoded;
 
     return next();

--- a/src/server/middlewares/chats/postChat.js
+++ b/src/server/middlewares/chats/postChat.js
@@ -1,0 +1,17 @@
+const axios = require('axios');
+
+// Read a token from the environment variables
+const token = process.env.SLACK_TOKEN;
+
+const postChat = async (text, channel, authToken = token) => {
+  try {
+    const res = await axios.post(
+      `https://slack.com/api/chat.postMessage?token=${authToken}&channel=${channel}&text=${text}`
+    );
+    return res.data;
+  } catch (err) {
+    throw err;
+  }
+};
+
+module.exports = { postChat };

--- a/src/server/middlewares/index.js
+++ b/src/server/middlewares/index.js
@@ -11,7 +11,7 @@ const validateUserId = require('./users/validateUserId');
 const validateNotePayload = require('./notes/validateNotePayload');
 const validateNoteId = require('./notes/validateNoteId');
 const slackUserRequest = require('./slack/getSlackInfo');
-
+const postChat = require('./chats/postChat');
 
 module.exports = {
   validateIncidentPayload,
@@ -22,5 +22,6 @@ module.exports = {
   validateUserId,
   validateNotePayload,
   validateNoteId,
-  slackUserRequest
+  slackUserRequest,
+  postChat,
 };

--- a/src/server/middlewares/slack/getSlackInfo.js
+++ b/src/server/middlewares/slack/getSlackInfo.js
@@ -8,6 +8,7 @@ async function createSlackUser({user: {id, profile}}) {
     models.slackUsers.create({
       id,
       username: profile.real_name,
+      email: profile.email,
     });
   }
 

--- a/src/server/migrations/20190328134329-create-slack-users.js
+++ b/src/server/migrations/20190328134329-create-slack-users.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  // eslint-disable-next-line max-lines-per-function
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('slackUsers', {
       id: {
@@ -10,6 +11,13 @@ module.exports = {
       },
       username: {
         type: Sequelize.STRING
+      },
+      email: {
+        type: Sequelize.STRING,
+        validate: {
+          isEmail: true
+        },
+        unique: true,
       },
       channelName: {
         type: Sequelize.STRING

--- a/src/server/migrations/20190808121942-create-slack-wire-events.js
+++ b/src/server/migrations/20190808121942-create-slack-wire-events.js
@@ -1,0 +1,48 @@
+'use strict';
+const cuid = require('cuid');
+
+module.exports = {
+  // eslint-disable-next-line max-lines-per-function
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('SlackWireEvents', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.STRING,
+        defaultValue: () => cuid(),
+      },
+      type: {
+        type: Sequelize.STRING,
+      },
+      eventTs: {
+        type: Sequelize.STRING,
+      },
+      userId: {
+        type: Sequelize.STRING,
+      },
+      ts: {
+        type: Sequelize.STRING,
+      },
+      text: {
+        type: Sequelize.TEXT,
+      },
+      channelId: {
+        type: Sequelize.STRING,
+      },
+      channelType: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('SlackWireEvents');
+  },
+};

--- a/src/server/models/slack-wire-events.js
+++ b/src/server/models/slack-wire-events.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const cuid = require('cuid');
+
+// eslint-disable-next-line max-lines-per-function
+module.exports = (sequelize, DataTypes) => {
+  const SlackWireEvents = sequelize.define(
+    'SlackWireEvents',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: DataTypes.STRING,
+        defaultValue: () => cuid(),
+      },
+      type: DataTypes.STRING,
+      eventTs: DataTypes.STRING,
+      userId: DataTypes.STRING,
+      ts: DataTypes.STRING,
+      text: DataTypes.TEXT,
+      channelId: DataTypes.STRING,
+      channelType: DataTypes.STRING,
+    },
+    {}
+  );
+  return SlackWireEvents;
+};

--- a/src/server/models/slackchannels.js
+++ b/src/server/models/slackchannels.js
@@ -14,9 +14,22 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false
     },
     channelMembers: DataTypes.STRING
-  }, {});
-  SlackChannels.associate = function(models) {
-    // associations can be defined here
-  };
+  }, {
+    classMethods: {
+      associate: (models) => {
+        SlackChannels.belongsTo(models.Incidents,{
+          foreignKey: 'IncidentId',
+          onDelete: 'CASCADE',
+          allowNull: false,
+        });
+        SlackChannels.hasMany(models.SlackWireEvents, {
+          foreignKey: 'channelId',
+          as: 'chats' 
+
+          
+        })
+      }
+    }
+  });
   return SlackChannels;
 };

--- a/src/server/models/slackevents.js
+++ b/src/server/models/slackevents.js
@@ -24,3 +24,4 @@ module.exports = (sequelize, DataTypes) => {
   });
   return slackEvents;
 };
+

--- a/src/server/models/slackusers.js
+++ b/src/server/models/slackusers.js
@@ -5,15 +5,25 @@ module.exports = (sequelize, DataTypes) => {
     id: {
       type: DataTypes.STRING,
       primaryKey: true,
+      allowNull: false,
     },
     username: DataTypes.STRING,
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isEmail: true,
+      },
+      unique: true,
+    },
     channelName: DataTypes.STRING
   }, {
     classMethods: {
       associate: (models) => {
-        slackUsers.hasOne(models.slackEvents, {
+        slackUsers.hasMany(models.SlackWireEvents, {
           foreignKey: 'userId',
-          as: 'slackEvents'
+          sourceKey: 'id',
+          as: 'chats'
         });
       }
     }

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -10,6 +10,7 @@ const rolesService = controllers.roles;
 const slackEventsService = controllers.slackEvents;
 const slackChannelsService = controllers.slackChannels;
 const { catchErrors } = controllers;
+const chatsService = controllers.appChats;
 
 // authorise routes
 const {
@@ -102,6 +103,8 @@ module.exports = app => {
       message: 'Welcome to WIRE.',
     });
   });
+  // chats endpoints
+  app.post('/api/chats', chatsService.createAppChat);
 
   app.use(catchErrors);
 };

--- a/src/server/seeders/slackChannels.js
+++ b/src/server/seeders/slackChannels.js
@@ -1,0 +1,11 @@
+const slack = require('../utils/data/slack-channels.json');
+
+module.exports = {
+  up(queryInterface) {
+    return queryInterface.bulkInsert('SlackChannels', slack.SlackChannels);
+  },
+
+  down(queryInterface) {
+    return queryInterface.bulkDelete('SlackChannels', null);
+  },
+};

--- a/src/server/seeders/slackEvents.js
+++ b/src/server/seeders/slackEvents.js
@@ -2,7 +2,7 @@ const slackEvent = require('../utils/data/slackEvents.json');
 
 module.exports = {
   up(queryInterface) {
-    return queryInterface.bulkInsert('slackEvents', slackEvent.slackEvents);
+    return queryInterface.bulkInsert('SlackWireEvents', slackEvent.slackEvents);
   },
 
   down(queryInterface) {

--- a/src/server/utils/data/slack-channels.json
+++ b/src/server/utils/data/slack-channels.json
@@ -1,0 +1,13 @@
+{
+  "SlackChannels": 
+  [
+   {
+    "incidentId": "cjfkubrlv0003tgxs3mre",
+    "channelId": "UHC32KE69",
+    "channelName": "test-channel",
+    "channelMembers":"testuser,testuser2",
+    "createdAt": "2019-03-07 11:08:03.326+03",
+    "updatedAt": "2019-03-07 11:08:03.326+03"
+   }
+ ]
+}

--- a/src/server/utils/data/slackUsers.json
+++ b/src/server/utils/data/slackUsers.json
@@ -3,6 +3,7 @@
     {
       "id": "UHC32KE69",
       "username": "wire2-chat-bot",
+      "email": "wire2.gmail.com",
       "channelName": "incident-reporting",
       "createdAt": "2019-03-08T14:54:51.710Z",
       "updatedAt": "2019-03-08T14:54:51.710Z"

--- a/src/server/utils/data/users.json
+++ b/src/server/utils/data/users.json
@@ -98,6 +98,17 @@
       "locationId": "cjee24n0n0000hfxsefer9tjh",
       "createdAt": "2019-03-08T14:54:51.710",
       "updatedAt": "2019-03-08T14:54:51.710"
+    },
+    {
+      "id": "cjl6fecrb11115vf09xly2fdgd",
+      "slackId": "UFLJZAEQP",
+      "email": "collins.otuoma@andela.com",
+      "username": "TheSteelGuy",
+      "imageUrl": "https://ca.slack-edge.com/T02R3LKBA-UC2JG34RE-6f54d41ef301-48",
+      "roleId": 3,
+      "locationId": "cjee24xnn0000i2xsh9qauyn5",
+      "createdAt": "2019-03-08T14:54:51.710",
+      "updatedAt": "2019-03-08T14:54:51.710"
     }
   ]
 }

--- a/src/tests/slackEvents.spec.js
+++ b/src/tests/slackEvents.spec.js
@@ -77,16 +77,6 @@ describe('SlackEvent Tests', () => {
       }, 4000);
     });
   });
-
-  it('should not create a SlackEvent given the wrong payload', done => {
-    sendRequest('post', slackEventEndpoint, testSlackEvent2, (err, req) => {
-      setTimeout(() => {
-        expect(req.body.status).toEqual('failure');
-        done();
-      }, 4000);
-    });
-  });
-
   it('should not create a SlackEvent twice', done => {
     sendRequest('post', slackEventEndpoint, testSlackEvent, (err, req) => {
       expect(req.body.message).toEqual('id must be unique');

--- a/src/tests/webChats.spec.js
+++ b/src/tests/webChats.spec.js
@@ -1,0 +1,76 @@
+const { sendRequest } = require('./helpers/request');
+const { postChat } = require('../server/middlewares/index');
+
+const webChatsEndpoint = '/api/chats';
+
+const testwebChat = {
+  text: 'I ama chat posted from wire web!!',
+  incidentId: 'cjfkubrlv0003tgxs3mre',
+};
+
+const testwebChat2 = {
+  text: '',
+  incidentId: 'cjfkubrlv0001tgxs3mre',
+};
+
+const testwebChat3 = {
+  text: 'I ama chat posted from wire web!!',
+  incidentId: 'noneexisting-hbjef',
+};
+
+// eslint-disable-next-line max-lines-per-function
+describe('web chat tests', () => {
+  it('should fail when empty chat text is empty', done => {
+    sendRequest('post', webChatsEndpoint, testwebChat2, (err, res) => {
+      expect(res.body.status).toEqual('failure');
+      expect(res.body.message).toEqual('Text is required');
+      done();
+    });
+  });
+  it('should fail if invalid token is provided', done => {
+    sendRequest(
+      // eslint-disable-next-line prettier/prettier
+      'post', webChatsEndpoint, testwebChat,(err, res) => {
+        expect(res.status).toEqual(401);
+      },
+      'some-invalidtoken'
+    );
+    done();
+  });
+  it('should fail if wrong incident id is passed', done => {
+    sendRequest('post', webChatsEndpoint, testwebChat3, (err, res) => {
+      expect(res.status).toEqual(400);
+      expect(res.body.message).toEqual('incident not found');
+    });
+    done();
+  });
+  it('should fail if wrong channelID id is passed', done => {
+    let res = postChat.postChat(
+      'some random chat',
+      'channelIDThatdoesNotExist'
+    );
+    res.then(slackRes => {
+      expect(slackRes.error).toEqual('channel_not_found');
+      expect(slackRes.ok).toEqual(false);
+      done();
+    });
+  });
+
+  it('should not call external api', done => {
+    postChat.postChat = jest.fn();
+    postChat.postChat('I ama chat posted from wire web!!', 'GLC1G3M0W');
+    expect(postChat.postChat).toHaveBeenCalledWith(
+      'I ama chat posted from wire web!!',
+      'GLC1G3M0W'
+    );
+    done();
+  });
+  it('test post chat throws error', done => {
+    postChat.postChat = jest.fn();
+    postChat.postChat.mockImplementation(() => {
+      throw new Error();
+    });
+    expect(postChat.postChat).toThrowError();
+    done();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
 - merges app chats table and slack event tables
 - add tests for the chore
 - enable seeding for the merged new table
 - Integrates  the existing add chat from the wire web  to the new merged table
 - sends chats posted from the wire web to the relevant slack channel

#### How should this be manually tested?
1. Clone the repo and  switch to the `ch-merge-slackevents-appchats-tables-167781111` branch.
2. cd to src directory and fire the backend application by `yarn start:dev`
- Send the request  body below to `POST api/slack/chats`
```{
  "token": "gUevdAHWJG6rKHW",
  "team_id": "TGX3UHAM8",
  "api_app_id": "AHC1KDL5B",
  "event": {
    "client_msg_id": "b35c818b-3434-4965-b033-b95007f96da3",
    "type": "message",
    "text": "Twitter/Facebook style",
    "user": "UHC32KE69",
    "ts": "1554828958.031500",
    "channel": "CGXDP5NQM",
    "event_ts": "1554828958.031500",
    "channel_type": "channel"
  },
  "type": "event_callback",
  "event_id": "EvHQFNGJEu",
  "event_time": 1554828958,
  "authed_users": ["UC113SZTL"]
}
```
Send the request  body below to `POST api/chats`
```
{
	"text":"test chat",
        "incidentId: "cjfkubrlv0003tgxs3mre"
}
```


#### Any background context you want to provide?
SlackWireEvents table should be populated instead slackEvent table and appchat table
#### What are the relevant pivotal tracker stories?
[167781111](https://www.pivotaltracker.com/n/projects/2117172/stories/167781111)
#### Screenshots (if appropriate)
N/A

